### PR TITLE
Fixed issue in README with unexpected token

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Installation:
 
 Synchronous processing of lines:
 
-	var LineByLineReader = require('line-by-line'),
+	var LineByLineReader = require('line-by-line');
 	var lr = new LineByLineReader('big_file.txt');
 
 	lr.on('error', function (err) {


### PR DESCRIPTION
Fixed an issue in the README example where the first line has a comma after a declaration, but then using var on the next line as though it was terminated with a semi-colon.
